### PR TITLE
Don't set breakpoint by default; better test results output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ exclude = .git,.ropeproject,.tox,docs,.git,build,env,venv
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE=tests.settings
-addopts = --reuse-db --benchmark-skip --pdbcls=IPython.core.debugger:Pdb
+addopts = --reuse-db --benchmark-skip -v


### PR DESCRIPTION
Debugging options like `--pdbcls=IPython.core.debugger:Pdb` and `--pdb` should be passed explicitly.