### PR TITLE
Remove unnnecessary dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,3 @@ fake-factory==0.7.2
 
 # Linting
 flake8==3.3.0
-
-# Utilities
-ipdb
-ipython


### PR DESCRIPTION
ipdb and IPython aren't project-specific requirements. It's up to developers to install these if they want.

Removing these will also speed up builds.