### PR TITLE
Handle .include(None)

### DIFF
--- a/include/query.py
+++ b/include/query.py
@@ -112,6 +112,8 @@ class IncludeQuerySet(models.QuerySet):
 
         # Copy the behavior of .select_related(None)
         if fields == (None, ):
+            for field in clone._includes.keys():
+                clone.query._annotations.pop('__{}'.format(field.name), None)
             clone._includes.clear()
             return clone
 


### PR DESCRIPTION
#### Purpose 
- Remove existing include annotations when using `.include(None)`

#### Changes
- Remove include annotations from `qs.query._annotations` (in addition to clearing `qs._includes`) when include field is None. 

