### PR TITLE
Upgrade pytest and pytest-django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,9 +2,8 @@ invoke==0.15.0
 
 # Testing
 pytest-benchmark==3.0.0
-pytest==3.0.6
-# pulling from github because master has django_assert_num_queries context mgr
-git+https://github.com/pytest-dev/pytest-django.git@master
+pytest==3.8.0
+pytest-django==3.4.3
 factory-boy==2.7.0
 fake-factory==0.7.2
 


### PR DESCRIPTION
No longer need to pin to pytest-django@master since
the latest release has assert_num_queries.

Needed to update pytest to avoid a VersionConflict error:

```
pkg_resources.VersionConflict: (pytest 3.0.6 (/Users/sloria/.pyenv/versions/3.6.5/envs/django-include/lib/python3.6/site-packages), Requirement.parse('pytest>=3.6'))
```